### PR TITLE
Returning the buffered word upon string end

### DIFF
--- a/hyphen.js
+++ b/hyphen.js
@@ -110,6 +110,9 @@
               return nextChar;
           }
         }
+        if (nextWord !== '') {
+          return nextWord;
+        }
       }
     }
   }


### PR DESCRIPTION
Your implementation works great, but you forgot to return the word if the string suddenly ends.

For your JS Fiddle example I have set the same strings without the special chars in the end.
You will notice that the last word is removed from the html node.
https://jsfiddle.net/nicosierra/yL1mhbc4/

In the following JS Fiddle you can see that by applying the changes on this PR, you can fix this behaviour. https://jsfiddle.net/nicosierra/eutvdeq8/
