### PR TITLE
Fixed scope of patterns variable

### DIFF
--- a/hyphen.js
+++ b/hyphen.js
@@ -247,11 +247,11 @@
         cache = {};
 
       // Preprocess patterns
-      patterns = (patternsDefinition.patterns.splice ? patternsDefinition.patterns : purifyPatterns(patternsDefinition.patterns)).map(function(
+    var patterns = (patternsDefinition.patterns.splice ? patternsDefinition.patterns : purifyPatterns(patternsDefinition.patterns)).map(function(
         pattern
       ) {
         return preprocessPattern(pattern);
-      }),
+      });
       // Prepare cache
     (patternsDefinition.exceptions.splice ? patternsDefinition.exceptions : purifyPatterns(patternsDefinition.exceptions)).forEach(function(exception) {
       cache[exception.replace(/\-/g, "")] = exception.replace(


### PR DESCRIPTION
Calling the createHyphenator() factory method several times after each other (for instance to create a German and then an English hyphenator function) results in overwritten patterns. If you then use the German hyphenator function it hyphenates using the English patterns.