### PR TITLE
Use unicode code point instead of literal unicode character in regex

### DIFF
--- a/hyphen.js
+++ b/hyphen.js
@@ -97,7 +97,7 @@
           nextWord = "";
 
         while ((nextChar = text.charAt(nextCharIndex++))) {
-          var charIsSpaceOrSpecial = /\s|[\!-\@\[-\`\{-\¿]/.test(nextChar);
+          var charIsSpaceOrSpecial = /\s|[\!-\@\[-\`\{-\xbf]/.test(nextChar);
 
           var state = !charIsSpaceOrSpecial
             ? states.readWord


### PR DESCRIPTION
[See this issue in `react-pdf` for a more in-depth explanation](https://github.com/diegomura/react-pdf/issues/529).

Long story short: if used with a minifier, this line can break, as it turns ```/\s|[\!-\@\[-\`\{-\¿]/``` into ```/\s|[\!-\@\[-\`\{-\\xbf]/```, which is no longer a valid regex.

Since I'm not too sure what this regex does, I used [`fast-check`](https://www.npmjs.com/package/fast-check) to test that the change doesn't break anything:
```js
const fc = require('fast-check');
const test = require('ava');

function oracle(t) {
  return /\s|[\!-\@\[-\`\{-\¿]/.test(t);
}

function newfn(t) {
  return /\s|[\!-\@\[-\`\{-\xbf]/.test(t);
}

test('is the same', t => {
  t.notThrows(() => {
    fc.assert(fc.property(fc.string(), (str => {
      return oracle(str) === newfn(str);
    })), { numRuns: 50000 });
  });
});
```

This generates 50000 different strings and compares the outputs. I did not get any errors.