### PR TITLE
Handle the edge case of a word “constructor” being interpreted as a JavaScript keyword.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.6.4] - 2021-04-04
+### Fixed
+- Handle the edge case of a word “constructor” being interpreted as a JavaScript keyword. - by [@arseni-mourzenko](https://github.com/arseni-mourzenko)
+
 ## [1.6.3] - 2021-04-04
 ### Fixed
 - Change undesired behavior of option `minWordLength`: value now can be set to less than 5 - by [@kamilmielnik](https://github.com/kamilmielnik)

--- a/hyphen.js
+++ b/hyphen.js
@@ -416,7 +416,7 @@
 
         switch (state) {
           case states.hyphenateWord:
-            if (!cache[nextTextChunk])
+            if (!Object.prototype.hasOwnProperty.call(cache, nextTextChunk))
               cache[nextTextChunk] = hyphenateWord(
                 nextTextChunk,
                 patterns,

--- a/scripts/package/package.json
+++ b/scripts/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyphen",
-  "version": "1.6.3",
+  "version": "1.6.4",
   "description": "Text hyphenation in Javascript.",
   "repository": {
     "type": "git",

--- a/src/start.js
+++ b/src/start.js
@@ -55,7 +55,7 @@ function start(
 
       switch (state) {
         case states.hyphenateWord:
-          if (!cache[nextTextChunk])
+          if (!Object.prototype.hasOwnProperty.call(cache, nextTextChunk))
             cache[nextTextChunk] = hyphenateWord(
               nextTextChunk,
               patterns,

--- a/tests/reserved-words.test.js
+++ b/tests/reserved-words.test.js
@@ -1,0 +1,14 @@
+const createHyphenator = require("../hyphen.js");
+const patterns = require("../patterns/en-us.js");
+
+let hyphenate;
+
+beforeAll(() => {
+  hyphenate = createHyphenator(patterns, { hyphenChar: "-" });
+});
+
+describe("Reserved words hyphenation", () => {
+  test("Should hyphenate constructor word correctly", () => {
+    expect(hyphenate("constructor")).toBe("con-struc-tor");
+  });
+});


### PR DESCRIPTION
In relation to https://github.com/ytiurin/hyphen/issues/39, here's the pull request which solves the issue.