### PR TITLE
Add async web worker support

### DIFF
--- a/src/create-hyphenator.js
+++ b/src/create-hyphenator.js
@@ -14,6 +14,8 @@ var _global =
     ? global
     : typeof window === "object"
     ? window
+    : typeof self === "object"
+    ? self
     : typeof this === "object"
     ? this
     : {};


### PR DESCRIPTION
When checking for Promise support, it does not include `self` which is available inside Web Workers.
`global`, `window` and `this` are not accessible inside a Web Worker.