### PR TITLE
add: option to use case insenstive rule

### DIFF
--- a/src/create-hyphenator.js
+++ b/src/create-hyphenator.js
@@ -6,12 +6,15 @@ var SETTING_DEFAULT_ASYNC = false,
   SETTING_DEFAULT_HTML = true,
   SETTING_DEFAULT_HYPH_CHAR = "\u00AD",
   SETTING_DEFAULT_MIN_WORD_LENGTH = 5,
+  SETTING_DEFAULT_CASE_INSENSITIVE = false,
   SETTING_NAME_ASYNC = "async",
   SETTING_NAME_DEBUG = "debug",
   SETTING_NAME_EXCEPTIONS = "exceptions",
   SETTING_NAME_HTML = "html",
   SETTING_NAME_HYPH_CHAR = "hyphenChar",
-  SETTING_NAME_MIN_WORD_LENGTH = "minWordLength";
+  SETTING_NAME_MIN_WORD_LENGTH = "minWordLength",
+  SETTING_NAME_CASE_INSENSITIVE = "caseInsensitive";
+  
 
 var _global =
   typeof global === "object"
@@ -82,6 +85,11 @@ export function createHyphenator(patternsDefinition, options) {
       SETTING_NAME_EXCEPTIONS,
       SETTING_DEFAULT_EXCEPTIONS,
       validateArray
+    ),
+    caseInsensitiveMode = keyOrDefault(
+      options,
+      SETTING_NAME_CASE_INSENSITIVE,
+      SETTING_DEFAULT_CASE_INSENSITIVE
     );
 
   // Prepare cache
@@ -156,7 +164,8 @@ export function createHyphenator(patternsDefinition, options) {
       localHyphenChar,
       skipHTML,
       localMinWordLength,
-      asyncMode
+      asyncMode,
+      caseInsensitiveMode
     );
   };
 }

--- a/tests/user-exceptions.test.js
+++ b/tests/user-exceptions.test.js
@@ -3,7 +3,7 @@ const patterns = require("../patterns/en-us.js");
 
 let hyphenate;
 
-beforeAll(() => {
+beforeEach(() => {
   hyphenate = createHyphenator(patterns, {
     hyphenChar: "-",
     exceptions: ["h-e-l-l-o"]
@@ -47,5 +47,66 @@ describe("User exceptions", () => {
     const predictable = "ta-ble project";
 
     expect(hyphenate(text)).toBe(predictable);
+  });
+
+  test("Factory function option is case sensitive by default", () => {
+    const textLower = "hello";
+    const textCapitalized = "Hello";
+    const textUpper = "HELLO"
+    const predictableLower = "h-e-l-l-o";
+    const predictableCapitalized = "Hel-lo";
+    const predictableUPPER = "HEL-LO";
+    expect(hyphenate(textLower)).toBe(predictableLower);
+    expect(hyphenate(textCapitalized)).toBe(predictableCapitalized);
+    expect(hyphenate(textUpper)).toBe(predictableUPPER);
+    expect(hyphenate(textLower)).toBe(predictableLower);
+    expect(hyphenate(textCapitalized)).toBe(predictableCapitalized);
+    expect(hyphenate(textCapitalized)).toBe(predictableCapitalized);
+    expect(hyphenate(textUpper)).toBe(predictableUPPER);
+    expect(hyphenate(textLower)).toBe(predictableLower);
+  });
+
+  test("Factory function option works case insensitive", () => {
+    const hyphenateWithCaseInsenstive = createHyphenator(patterns, {
+      hyphenChar: "-",
+      exceptions: ["h-e-l-l-o"],
+      caseInsensitive: true,
+    });
+    const textLower = "hello";
+    const textCapitalized = "Hello";
+    const textUpper = "HELLO"
+    const predictableLower = "h-e-l-l-o";
+    const predictableCapitalized = "H-e-l-l-o";
+    const predictableUPPER = "H-E-L-L-O";
+    expect(hyphenateWithCaseInsenstive(textLower)).toBe(predictableLower);
+    expect(hyphenateWithCaseInsenstive(textCapitalized)).toBe(predictableCapitalized);
+    expect(hyphenateWithCaseInsenstive(textUpper)).toBe(predictableUPPER);
+    expect(hyphenateWithCaseInsenstive(textLower)).toBe(predictableLower);
+    expect(hyphenateWithCaseInsenstive(textCapitalized)).toBe(predictableCapitalized);
+    expect(hyphenateWithCaseInsenstive(textCapitalized)).toBe(predictableCapitalized);
+    expect(hyphenateWithCaseInsenstive(textUpper)).toBe(predictableUPPER);
+    expect(hyphenateWithCaseInsenstive(textLower)).toBe(predictableLower);
+  });
+
+  test("Factory function option works case insensitive and case insenstive works with multi character hyphens", () => {
+    const hyphenateWithMultiCharHyphen = createHyphenator(patterns, {
+      hyphenChar: "- ",
+      exceptions: ["h-e-l-l-o"],
+      caseInsensitive: true,
+    });
+    const textLower = "hello";
+    const textCapitalized = "Hello";
+    const textUpper = "HELLO"
+    const predictableLower = "h- e- l- l- o";
+    const predictableCapitalized = "H- e- l- l- o";
+    const predictableUPPER = "H- E- L- L- O";
+    expect(hyphenateWithMultiCharHyphen(textLower)).toBe(predictableLower);
+    expect(hyphenateWithMultiCharHyphen(textCapitalized)).toBe(predictableCapitalized);
+    expect(hyphenateWithMultiCharHyphen(textUpper)).toBe(predictableUPPER);
+    expect(hyphenateWithMultiCharHyphen(textLower)).toBe(predictableLower);
+    expect(hyphenateWithMultiCharHyphen(textCapitalized)).toBe(predictableCapitalized);
+    expect(hyphenateWithMultiCharHyphen(textCapitalized)).toBe(predictableCapitalized);
+    expect(hyphenateWithMultiCharHyphen(textUpper)).toBe(predictableUPPER);
+    expect(hyphenateWithMultiCharHyphen(textLower)).toBe(predictableLower);
   });
 });


### PR DESCRIPTION
Rule is for not having to write all different variants of casing to the exceptions list for a word.

You can just write one example for a word like h-e-l-l-o and it will apply even if it is capitalized or all uppercased.

By default the setting is off but it can be enabled when using createHyphenator function.